### PR TITLE
Fix current series might raise Rubicure::NotOnAirError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+
+gem "timecop", :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -205,6 +206,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets (< 4.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -107,15 +107,30 @@ QUERYSTRING
 QUERYSTRING
     end
 
-    context "now" do
+    context "now at 2020-01-26" do
+      around do |e|
+        Timecop.freeze('2020-01-26') { e.run }
+      end
       it "returns current series" do
         expect(result["data"]["now"]["seriesName"]).to eq Precure.now.series_name
       end
     end
 
-    context "current" do
+    context "current at 2020-01-26" do
+      around do |e|
+        Timecop.freeze('2020-01-26') { e.run }
+      end
       it "returns current series" do
         expect(result["data"]["current"]["seriesName"]).to eq Precure.now.series_name
+      end
+    end
+
+    context "at 2020-02-01" do
+      around do |e|
+        Timecop.freeze('2020-02-01') { e.run }
+      end
+      it "returns error" do
+        expect { result }.to raise_error(Rubicure::NotOnAirError)
       end
     end
   end
@@ -132,6 +147,9 @@ QUERYSTRING
 QUERYSTRING
     end
 
+    around do |e|
+      Timecop.freeze('2020-01-26') { e.run }
+    end
     it "returns current series" do
       expect(result["data"]["series"]["seriesName"]).to eq Precure.now.series_name
     end
@@ -149,6 +167,9 @@ QUERYSTRING
 QUERYSTRING
     end
 
+    around do |e|
+      Timecop.freeze('2020-01-26') { e.run }
+    end
     it "returns current series" do
       expect(result["data"]["series"]["seriesName"]).to eq Precure.now.series_name
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'timecop'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
Timecop.freeze('2020-02-01')
Precure.now

raises Rubicure::NotOnAirError

「スター☆トゥインクルプリキュア」放送終了 2020-01-26
「ヒーリングっど♥プリキュア」放送開始 2020-02-02