### PR TITLE
Bump bundler from 2.2.22 to 2.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && \
 apk upgrade && \
 apk add --update --no-cache --virtual=build-dependencies build-base sqlite-dev npm gmp-dev && \
 apk add --update --no-cache nodejs sqlite-libs tzdata && \
-gem install bundler -v 2.2.22 && \
+gem install bundler -v 2.3.6 && \
 npm -g install yarn && \
 bundle config force_ruby_platform true && \
 bundle install -j4 && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.22
+   2.3.6

--- a/ci/ruby2.6/Dockerfile
+++ b/ci/ruby2.6/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && \
 apk upgrade && \
 apk add --update --no-cache --virtual=build-dependencies build-base sqlite-dev npm gmp-dev && \
 apk add --update --no-cache nodejs sqlite-libs tzdata && \
-gem install bundler -v 2.2.22 && \
+gem install bundler -v 2.3.6 && \
 npm -g install yarn

--- a/ci/ruby2.7/Dockerfile
+++ b/ci/ruby2.7/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && \
 apk upgrade && \
 apk add --update --no-cache --virtual=build-dependencies build-base sqlite-dev npm gmp-dev && \
 apk add --update --no-cache nodejs sqlite-libs tzdata && \
-gem install bundler -v 2.2.22 && \
+gem install bundler -v 2.3.6 && \
 npm -g install yarn

--- a/ci/ruby3.0/Dockerfile
+++ b/ci/ruby3.0/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && \
 apk upgrade && \
 apk add --update --no-cache --virtual=build-dependencies build-base sqlite-dev npm gmp-dev && \
 apk add --update --no-cache nodejs sqlite-libs tzdata && \
-gem install bundler -v 2.2.22 && \
+gem install bundler -v 2.3.6 && \
 npm -g install yarn

--- a/ci/ruby3.1/Dockerfile
+++ b/ci/ruby3.1/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && \
 apk upgrade && \
 apk add --update --no-cache --virtual=build-dependencies build-base sqlite-dev npm gmp-dev && \
 apk add --update --no-cache nodejs sqlite-libs tzdata && \
-gem install bundler -v 2.2.22 && \
+gem install bundler -v 2.3.6 && \
 npm -g install yarn


### PR DESCRIPTION
Suppress "Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead."