### PR TITLE
Set a css_compressor so sassc-rails does not overwrite the compressor…

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
+  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
… when running the tests

cf. https://github.com/sass/sassc-rails/issues/93